### PR TITLE
Make GZIP compression asynchronous

### DIFF
--- a/lib/compression.ts
+++ b/lib/compression.ts
@@ -1,7 +1,11 @@
 // NOTICE: This is the NodeJS implementation.
 // The browser implementation is ./browser/compression.ts
 import zlib from 'zlib';
+import { promisify } from 'util';
 import snappy from 'snappyjs';
+
+const gzipAsync = promisify(zlib.gzip);
+const gunzipAsync = promisify(zlib.gunzip);
 
 type PARQUET_COMPRESSION_METHODS = Record<
   string,
@@ -31,7 +35,7 @@ export const PARQUET_COMPRESSION_METHODS: PARQUET_COMPRESSION_METHODS = {
   ZSTD: {
     deflate: deflate_zstd,
     inflate: inflate_zstd,
-  }
+  },
 };
 
 /**
@@ -50,7 +54,7 @@ function deflate_identity(value: ArrayBuffer | Buffer | Uint8Array) {
 }
 
 function deflate_gzip(value: ArrayBuffer | Buffer | string) {
-  return zlib.gzipSync(value);
+  return gzipAsync(value);
 }
 
 function deflate_snappy(value: ArrayBuffer | Buffer | Uint8Array) {
@@ -81,7 +85,7 @@ async function inflate_identity(value: ArrayBuffer | Buffer | Uint8Array): Promi
 }
 
 async function inflate_gzip(value: Buffer | ArrayBuffer | string) {
-  return zlib.gunzipSync(value);
+  return gunzipAsync(value);
 }
 
 function inflate_snappy(value: ArrayBuffer | Buffer | Uint8Array) {

--- a/test/compression.test.ts
+++ b/test/compression.test.ts
@@ -1,0 +1,23 @@
+import { assert } from 'chai';
+import sinon from 'sinon';
+import zlib from 'zlib';
+import { deflate, inflate } from '../lib/compression';
+
+describe('compression', function () {
+  afterEach(function () {
+    sinon.restore();
+  });
+
+  it('performs GZIP operations without synchronous zlib calls', async function () {
+    const gzipSyncSpy = sinon.spy(zlib, 'gzipSync');
+    const gunzipSyncSpy = sinon.spy(zlib, 'gunzipSync');
+    const input = Buffer.from('parquet data '.repeat(100));
+
+    const compressed = await deflate('GZIP', input);
+    const decompressed = await inflate('GZIP', compressed);
+
+    assert.deepEqual(decompressed, input);
+    sinon.assert.notCalled(gzipSyncSpy);
+    sinon.assert.notCalled(gunzipSyncSpy);
+  });
+});


### PR DESCRIPTION
## Purpose

GZIP compression and decompression are exposed through asynchronous functions, but currently call synchronous zlib APIs internally. Large pages can therefore block the Node.js event loop and delay unrelated work.

## Related GitHub Issues

None.

## Solution

Promisify the asynchronous zlib GZIP functions once at module initialization and return their promises from the existing compression methods. This preserves the current public API and default compression settings.

## Change summary

- Replace gzipSync with promisified gzip.
- Replace gunzipSync with promisified gunzip.
- Add a GZIP round-trip regression test that verifies neither synchronous zlib API is called.

## Steps to Verify

1. Run npm ci.
2. Run npm test.
3. Run npm run type.
4. Run npm run lint.
5. Run npm run build.
6. Run npm run build:browser.

## Additional details

- Full test result: 313 passing, 2 pending.
- The Node and browser builds complete successfully.
- This intentionally leaves the default GZIP compression level unchanged; exposing compression options can be considered separately without coupling it to the event-loop fix.