### PR TITLE
fix: build package before publishing

### DIFF
--- a/.github/workflows/publish-next.yml
+++ b/.github/workflows/publish-next.yml
@@ -24,6 +24,9 @@ jobs:
         env:
           FULL_SHA: ${{ github.sha }}
 
+      - name: Build 📦
+        run: npm run prepublishOnly
+
       - name: Publish @next 🚂
         run: npm publish --tag next --access public
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,5 +24,8 @@ jobs:
       - name: Version ⬆️
         run: npm version ${{ github.event.release.tag_name }} --no-git-tag-version
 
+      - name: Build 📦
+        run: npm run prepublishOnly
+
       - name: Publish 🚂
         run: npm publish --tag latest


### PR DESCRIPTION
The repository disables npm lifecycle scripts via .npmrc, while the package's dist/ output is generated only by prepublishOnly. The release and @next workflows therefore publish packages without dist/, even though package.json points to dist/parquet.js.\n\nThis change explicitly runs prepublishOnly after versioning in both workflows. It keeps ignore-scripts=true for dependency installation and ensures generated artifacts are present before npm publish.